### PR TITLE
Increment lastTestedNVDAVersion

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2022.1.0",
+	"addon_lastTestedNVDAVersion" : "2023.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
I tested the addon with the last stable NVDA version which is 2023.1.
All functions of the module work as expected.
