### PR TITLE
Fix AttributeError when accessing windowClassName on _SecureDesktopNVDAObject

### DIFF
--- a/addon/globalPlugins/consoleToolkit.py
+++ b/addon/globalPlugins/consoleToolkit.py
@@ -1291,10 +1291,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         self.beeper = Beeper()
 
     def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-        if getConfig("controlVInConsole") and obj.windowClassName == 'ConsoleWindowClass':
-            clsList.insert(0, ConsoleControlV)
-        if getConfig("controlVInConsole") and obj.windowClassName == 'PuTTY':
-            clsList.insert(0, PuttyControlV)
+        if getConfig("controlVInConsole"):
+            window_class_name = getattr(obj, 'windowClassName', None)
+            if window_class_name == 'ConsoleWindowClass':
+                clsList.insert(0, ConsoleControlV)
+            elif window_class_name == 'PuTTY':
+                clsList.insert(0, PuttyControlV)
 
 
     def createMenu(self):


### PR DESCRIPTION
Fixes: #8

## Description:

This PR fixes the issue described in #8, where accessing the windowClassName attribute on certain objects, like _SecureDesktopNVDAObject, causes an AttributeError. The issue is resolved by using getattr() to safely access the windowClassName attribute, preventing crashes when the attribute is missing.


## Changes:
* Replaced direct access to obj.windowClassName with getattr(obj, 'windowClassName', None) for safe attribute access.
* Simplified redundant checks for getConfig("controlVInConsole").


