### PR TITLE
Replace deprecated WinTerminalUIA to ensure NVDA 2025.1+ compatibility

### DIFF
--- a/addon/globalPlugins/consoleToolkit.py
+++ b/addon/globalPlugins/consoleToolkit.py
@@ -54,7 +54,8 @@ import winUser
 import wx
 import globalCommands
 import scriptHandler
-from NVDAObjects.UIA.winConsoleUIA import WinTerminalUIA
+from UIAHandler.utils import _shouldUseWindowsTerminalNotifications
+from NVDAObjects.UIA.winConsoleUIA import _DiffBasedWinTerminalUIA, _NotificationsBasedWinTerminalUIA
 
 winmm = ctypes.windll.winmm
 
@@ -699,7 +700,7 @@ def myReview_top(self, gesture: inputCore.InputGesture):
     review=api.getReviewPosition()
     obj = review.obj
     count=scriptHandler.getLastScriptRepeatCount()
-    if not getConfig("overrideTopReview") or count >= 1 or not isinstance(obj, WinTerminalUIA):
+    if not getConfig("overrideTopReview") or count >= 1 or not isinstance(obj, (_NotificationsBasedWinTerminalUIA if _shouldUseWindowsTerminalNotifications() else _DiffBasedWinTerminalUIA)):
         return originalReview_top(gesture)
 
     def speakInfo(info):


### PR DESCRIPTION
### Description:
- Replaced the deprecated `WinTerminalUIA` to maintain compatibility with NVDA 2025.1.  
  (`WinTerminalUIA` was deprecated in NVDA 2023.1 [Issue #14047](https://github.com/nvaccess/nvda/issues/14047) and removed in NVDA 2025.1 [Issue #16820](https://github.com/nvaccess/nvda/issues/16820)).
- Updated the add-on to use `_DiffBasedWinTerminalUIA` or `_NotificationsBasedWinTerminalUIA` as the recommended replacements.
