### PR TITLE
Bump version to 1.4.4 and add Finnish translation

### DIFF
--- a/addon/globalPlugins/consoleToolkit.py
+++ b/addon/globalPlugins/consoleToolkit.py
@@ -156,7 +156,7 @@ class SettingsDialog(SettingsPanel):
       # Output capture chime  volume slider
         sizer=wx.BoxSizer(wx.HORIZONTAL)
         label=wx.StaticText(self,wx.ID_ANY,label=_("Volume of chime while capturing command output"))
-        slider=wx.Slider(self, wx.ID_ANY, minValue=0,maxValue=100)
+        slider=wx.Slider(self, wx.NewId(), minValue=0,maxValue=100)
         slider.SetValue(getConfig("captureChimeVolume"))
         sizer.Add(label)
         sizer.Add(slider)
@@ -216,7 +216,7 @@ class Beeper:
             channels=2,
             samplesPerSec=int(tones.SAMPLE_RATE),
             bitsPerSample=16,
-            outputDevice=config.conf["speech"]["outputDevice"],
+            outputDevice=config.conf["audio"]["outputDevice"],
             wantDucking=False
         )
 

--- a/addon/locale/fi/lc_messages/nvda.po
+++ b/addon/locale/fi/lc_messages/nvda.po
@@ -1,0 +1,204 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: 'consoleToolkit' '1.4.3'\n"
+"Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
+"POT-Creation-Date: 2025-04-20 16:49+0300\n"
+"PO-Revision-Date: 2025-04-20 17:00+0300\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.6\n"
+
+#. Translators: Title for the settings dialog
+#: addon\globalPlugins\consoleToolkit.py:116
+msgid "Console Toolkit settings"
+msgstr "Konsolityökalun asetukset"
+
+#. checkbox console realtime
+#. Translators: Checkbox for realtime console
+#: addon\globalPlugins\consoleToolkit.py:124
+msgid "Speak console output in realtime"
+msgstr "Puhu konsolin tuloste reaaliajassa"
+
+#. checkbox console beep
+#. Translators: Checkbox for console beep on update
+#: addon\globalPlugins\consoleToolkit.py:129
+msgid "Beep on update in consoles"
+msgstr "Anna äänimerkki konsolin päivittyessä"
+
+#. checkbox enforce control+V in console
+#. Translators: Checkbox for control+V enforcement in console
+#: addon\globalPlugins\consoleToolkit.py:134
+msgid "Always enable Control+V in console (useful for SSH)"
+msgstr ""
+"Ota Ctrl+V käyttöön kaikissa konsoleissa (käytännöllinen SSH:ta käytettäessä)"
+
+#. Delete method Combo box
+#. Translators: Label for delete line method for prompt editing combo box
+#: addon\globalPlugins\consoleToolkit.py:140
+msgid "Method of deleting lines for prompt editing:"
+msgstr "Rivien poistotapa kehotteessa:"
+
+#. Capture suffix edit
+#: addon\globalPlugins\consoleToolkit.py:145
+msgid "Suffix to be appendedd to commands in output capturing mode."
+msgstr "Komentoihin lisättävä pääte keräystilassa."
+
+#. capture open option combo box
+#: addon\globalPlugins\consoleToolkit.py:148
+msgid "Open captured output in"
+msgstr "Avaa kerätty tuloste sovelluksessa"
+
+#. Capture timeout edit
+#: addon\globalPlugins\consoleToolkit.py:153
+msgid "Capture timeout in seconds:"
+msgstr "Keräyksen aikakatkaisu (sekuntia):"
+
+#: addon\globalPlugins\consoleToolkit.py:158
+msgid "Volume of chime while capturing command output"
+msgstr "Keräysäänimerkin voimakkuus"
+
+#. checkbox override review top line behavior
+#: addon\globalPlugins\consoleToolkit.py:166
+msgid ""
+"Override shift+numPad7 behavior to take review cursor to the first visible "
+"line"
+msgstr ""
+"Pakota Shift+NumPad7 siirtämään tarkastelukohdistin ensimmäiselle näkyvälle "
+"riville"
+
+#. checkbox override repeated review curosr events
+#: addon\globalPlugins\consoleToolkit.py:170
+msgid "Ignore repeated route review cursor events"
+msgstr "Älä huomioi peräkkäisiä tarkastelukohdistimen reititystapahtumia"
+
+#: addon\globalPlugins\consoleToolkit.py:180
+msgid "Capture timeout must be a positive integer"
+msgstr "Keräyksen aikakatkaisun on oltava positiivinen numero"
+
+#: addon\globalPlugins\consoleToolkit.py:408
+msgid "Edit text"
+msgstr "Muokkaa tekstiä"
+
+#. Translators: Title of  dialog
+#: addon\globalPlugins\consoleToolkit.py:512
+msgid "Command output"
+msgstr "Komentotuloste"
+
+#: addon\globalPlugins\consoleToolkit.py:706
+msgid "Failed to set review positionreveiew "
+msgstr "Tarkastelukohdistimen asettaminen epäonnistui: "
+
+#: addon\globalPlugins\consoleToolkit.py:778
+msgid "Pasted"
+msgstr "Liitetty"
+
+#: addon\globalPlugins\consoleToolkit.py:890
+msgid "Edit prompt"
+msgstr "Muokkaa kehotetta"
+
+#: addon\globalPlugins\consoleToolkit.py:891
+msgid ""
+"Opens accessible window that allows to edit current command line prompt."
+msgstr "Avaa saavutettavan ikkunan, jossa voit muokata nykyistä kehotetta."
+
+#: addon\globalPlugins\consoleToolkit.py:896
+msgid "Capture command output"
+msgstr "Kerää komentotuloste"
+
+#: addon\globalPlugins\consoleToolkit.py:897
+msgid "Executes command, captures output and presents it in accessible window."
+msgstr ""
+"Suorittaa komennon, kerää tulosteen ja näyttää sen saavutettavassa ikkunassa."
+
+#: addon\globalPlugins\consoleToolkit.py:930
+msgid "Control character found on the screen; clear window and try again."
+msgstr "Control havaittu näytöllä; tyhjennä ikkuna ja yritä uudelleen."
+
+#: addon\globalPlugins\consoleToolkit.py:955
+#: addon\globalPlugins\consoleToolkit.py:985
+msgid "Timed out while waiting for control characters to appear."
+msgstr "Aikakatkaisu odotettaessa."
+
+#: addon\globalPlugins\consoleToolkit.py:1078
+msgid ""
+"Control+C: works in both cmd.exe and bash, but leaves previous prompt "
+"visible on the screen; doesn't work in emacs; sometimes unreliable on slow "
+"SSH connections"
+msgstr ""
+"CONTROL+C: Toimii sekä cmd.exessä että bashissa, mutta jättää aikaisemman "
+"komennon näkyväksi näytölle; ei toimi Emacsissa; Joskus epäluotettava "
+"hitaissa SSH -yhteyksissä"
+
+#: addon\globalPlugins\consoleToolkit.py:1079
+msgid "Escape: works only in cmd.exe"
+msgstr "Escape: Toimii vain cmd.exessä"
+
+#: addon\globalPlugins\consoleToolkit.py:1080
+msgid "Control+A Control+K: works in bash and emacs; doesn't work in cmd.exe"
+msgstr "CONTROL+A CONTROL+K: Toimii bashissa ja emacsissa; ei toimi cmd.exessä"
+
+#: addon\globalPlugins\consoleToolkit.py:1081
+msgid ""
+"Backspace (recommended): works in all environments; however slower and may "
+"cause corruption if the length of the line has changed"
+msgstr ""
+"Backspace (suositus): Toimii kaikissa ympäristöissä; on Kuitenkin hitaampi "
+"ja voi aiheuttaa korruptiota, jos rivin pituus on muuttunut"
+
+#: addon\globalPlugins\consoleToolkit.py:1166
+msgid "Timed out while waiting for modifiers to be released!"
+msgstr "Aikakatkaisu odotettaessa muokkaimien vapautumista!"
+
+#: addon\globalPlugins\consoleToolkit.py:1198
+msgid "Capture interrupted!"
+msgstr "Keräys keskeytetty!"
+
+#: addon\globalPlugins\consoleToolkit.py:1242
+msgid "Timed out while waiting for command output!"
+msgstr "Aikakatkaisu odotettaessa tulostetta!"
+
+#: addon\globalPlugins\consoleToolkit.py:1251
+msgid "Copy to clipboard"
+msgstr "Kopioi leikepöydälle"
+
+#: addon\globalPlugins\consoleToolkit.py:1252
+msgid "Open in temporary window"
+msgstr "Avaa väliaikaisessa ikkunassa"
+
+#: addon\globalPlugins\consoleToolkit.py:1253
+msgid "Open in Notepad"
+msgstr "Avaa Muistiossa"
+
+#: addon\globalPlugins\consoleToolkit.py:1254
+msgid "Open in Notepad++"
+msgstr "Avaa Notepad++:ssa"
+
+#: addon\globalPlugins\consoleToolkit.py:1261
+msgid "Command output copied to clipboard"
+msgstr "Komennon tuloste kopioitu leikepöydälle"
+
+#: addon\globalPlugins\consoleToolkit.py:1305
+msgid "Console toolkit"
+msgstr "Konsolityökalu"
+
+#. Add-on summary, usually the user visible name of the addon.
+#. Translators: Summary for this add-on to be shown on installation and add-on information.
+#: buildVars.py:17
+msgid "Console Toolkit"
+msgstr "Konsolityökalu"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
+#: buildVars.py:20
+msgid "Accessibility improvements for Windows console."
+msgstr "Windows -konsolin saavutettavuusparannuksia."

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Accessibility improvements for Windows console."""),
 	# version
-	"addon_version" : "1.4.3",
+	"addon_version" : "1.4.4",
 	# Author(s)
 	"addon_author" : u"Tony Malykh <anton.malykh@gmail.com>",
 	# URL for the add-on documentation support
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2024.1",
+	"addon_lastTestedNVDAVersion" : "2025.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
This also fixes a conf issue; outputDevice is nowadays in audio, not speech. IN 1.4.3 audio was used, generating an NVDA error on startup.